### PR TITLE
Improve hints for methods used on wrong types

### DIFF
--- a/she/interp.py
+++ b/she/interp.py
@@ -876,7 +876,7 @@ class Interpreter:
 
     # --- members and indexing ---------------------------------------------
     def get_member(self, obj, name, node):
-        from .stdlib import member_of
+        from .stdlib import member_of, module_for_method
         if isinstance(obj, Module):
             if name in obj.values:
                 return obj.values[name]
@@ -915,8 +915,15 @@ class Interpreter:
             raise TypeErr(f"there is nothing here, so `.{name}` has no meaning",
                           node.pos, node.end,
                           hint="use `?.` to skip safely when a value might be nothing.")
+        hint = did_you_mean(name, member_names(obj))
+        if hint is None:
+            module_name = module_for_method(name)
+            if module_name is not None:
+                value_type = "map" if module_name == "maps" else module_name
+                hint = (f"`{name}` is a {value_type} function; "
+                        f"use it on a {value_type} value.")
         raise NameErr(f"a {type_name(obj)} has no `{name}`", node.pos, node.end,
-                      hint=did_you_mean(name, member_names(obj)))
+                      hint=hint)
 
     def set_member(self, obj, name, value, node):
         if isinstance(obj, Instance):

--- a/she/stdlib/__init__.py
+++ b/she/stdlib/__init__.py
@@ -179,6 +179,15 @@ def members_for(obj):
     return names
 
 
+def module_for_method(name):
+    """Return the stdlib module that provides a value method, if any."""
+    tables = method_tables()
+    for module_name, py_type in _TABLE_SOURCES.items():
+        if name in tables.get(py_type, {}):
+            return module_name
+    return None
+
+
 # --- core: available without importing anything -----------------------------
 
 # Modules you can use without importing. They are pure computation, so having

--- a/tests/test_language.py
+++ b/tests/test_language.py
@@ -264,6 +264,15 @@ def test_text_methods_and_module_agree():
     assert go('say text.upper("hi")').strip() == "HI"
 
 
+def test_method_on_wrong_type_suggests_the_right_type():
+    error = fails("say [1, 2].upper()")
+    assert "list has no `upper`" in error.message
+    assert "text function" in (error.hint or "")
+    error = fails('say "hi".sum()')
+    assert "text has no `sum`" in error.message
+    assert "list function" in (error.hint or "")
+
+
 def test_missing_key_suggests():
     error = fails('let m = {name: "x"}\nsay m["nme"]')
     assert "no key" in error.message


### PR DESCRIPTION
## Summary

- detect when an unknown method is provided by another built-in value type
- add an actionable hint that names the correct value type
- cover both list-to-text and text-to-list mistakes

## Before

```text
NameError: a list has no `upper`
```

## After

```text
NameError: a list has no `upper`
  help: `upper` is a text function; use it on a text value.
```

## Checks

- `pytest` (151 passed)
- `she test examples` (8 passed)
- `python tools/check_sandbox.py` (sandbox held)
- `ruff check she/interp.py she/stdlib/__init__.py tests/test_language.py`

Addresses the wrong-type method error gap in #12.