### PR TITLE
Add list.rotate to the standard library

### DIFF
--- a/she/stdlib/basics.py
+++ b/she/stdlib/basics.py
@@ -304,6 +304,14 @@ def _list_module():
         """A reversed copy."""
         return list(reversed(_need_list(xs, "reverse")))
 
+    def rotate(xs, n):
+        """Move the first n items to the end. A negative n goes the other way."""
+        items = _need_list(xs, "rotate")
+        if not items:
+            return []
+        n = int(n) % len(items)
+        return items[n:] + items[:n]
+
     def sort(interp, xs, by=None, descending=False):
         """A sorted copy. Pass `by` to sort on a computed value."""
         items = list(_need_list(xs, "sort"))
@@ -468,7 +476,8 @@ def _list_module():
         "remove": remove, "remove_at": remove_at, "clear": clear,
         "index_of": index_of, "contains": contains, "slice": slice_,
         "take": take, "drop": drop, "first": first, "last": last,
-        "reverse": reverse, "sort": sort, "unique": unique, "flatten": flatten,
+        "reverse": reverse, "rotate": rotate, "sort": sort, "unique": unique,
+        "flatten": flatten,
         "chunk": chunk, "group_by": group_by, "find": find,
         "find_index": find_index, "partition": partition, "sum": sum_,
         "average": average, "mean": average, "zip": zip_, "join": join,

--- a/tests/test_language.py
+++ b/tests/test_language.py
@@ -557,6 +557,13 @@ def test_list_module():
     assert go("say [1,2,3].average()").strip() == "2"
 
 
+def test_list_rotate():
+    assert go("say [1,2,3,4].rotate(1)").strip() == "[2, 3, 4, 1]"
+    assert go("say [1,2,3,4].rotate(-1)").strip() == "[4, 1, 2, 3]"
+    assert go("say [1,2,3].rotate(4)").strip() == "[2, 3, 1]"
+    assert go("say [].rotate(3)").strip() == "[]"
+
+
 def test_list_sort_by():
     source = 'say [{n: 2}, {n: 1}] |> list.sort(by: fun(m) -> m.n) |> to_text()'
     assert "1" in go(source)


### PR DESCRIPTION
## Summary
- add list.rotate for moving items in either direction
- preserve the input list and handle empty lists
- cover positive, negative, wrapped, and empty rotations

## Tests
- python -m pytest (151 passed)
- she test examples (8 passed)
- python tools/check_sandbox.py
- ruff check she/stdlib/basics.py tests/test_language.py

Addresses #11